### PR TITLE
Seurat v4 Updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,4 @@ URL: https://github.com/crazyhottommy/scclusteval
 BugReports: https://github.com/crazyhottommy/scclusteval/issues
 VignetteBuilder: knitr
 Depends:
-    Seurat
+    Seurat (>= 4.0.0)


### PR DESCRIPTION
Main change is no longer trying to run the Jackstraw procedure after SCTransform, as this is no longer supported.  Also add a "useSCTransform" argument, which is set to TRUE by default.